### PR TITLE
Voice List fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.qmake*
+Makefile
+ui_*.h
+moc_*.h
+moc_*.cpp
+qrc_*.cpp
+Papagayo
+*.o
+/.vscode/

--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ What you've downloaded here is the source code to Papagayo. You can modify and b
 as you wish, as long as you follow the terms in the License.txt file.
 
 Papagayo is currently built as a Qt application. To build it you need Qt 5.2.1 installed.
-I have built Papagayo for Windows and MacOS X, but I expect it will build for Linux as
-well. If anyone wants to try out a Linux build, go for it.
+It is known to build for Windows, Linux and Mac.
 
 To build Papagayo, open up the file Papagayo.pro in Qt Creator and press the Build
-Project button.
+Project button. Or, using the command line, you can call `qmake` then `make`.
 
 Papagayo is currently in active development, so please check back for newer versions.
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -43,7 +43,7 @@ private slots:
 	void onFpsChange(QString text);
 	void onNewVoice();
 	void onDeleteVoice();
-	void onVoiceSelected(QListWidgetItem *item);
+	void onVoiceSelected(QListWidgetItem *item, QListWidgetItem* previous);
 	void onVoiceItemChanged(QListWidgetItem *item);
 	void onVoiceNameChanged();
 	void onVoiceTextChanged();
@@ -51,11 +51,10 @@ private slots:
 	void onExport();
 
 private:
-	void RebuildVoiceList();
+	void buildVoiceList();
 
 	LipsyncDoc			*fDoc;
 	bool				fEnableAutoBreakdown;
-	bool				fRebuildingList;
 	int					fDefaultFps;
 
 	Ui::MainWindow *ui;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -689,9 +689,9 @@
   </connection>
   <connection>
    <sender>voiceList</sender>
-   <signal>itemClicked(QListWidgetItem*)</signal>
+   <signal>currentItemChanged(QListWidgetItem*,QListWidgetItem*)</signal>
    <receiver>MainWindow</receiver>
-   <slot>onVoiceSelected(QListWidgetItem*)</slot>
+   <slot>onVoiceSelected(QListWidgetItem*,QListWidgetItem*)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>704</x>


### PR DESCRIPTION
A number of fixes:
(1) The Open button now allows sound files to be opened as well as .pgo files (simple one-liner)
(2) Papagayo could start up in an unusable state (everything grayed out after opening a file) -- this was because fRebuildingList was not initialized
(3) Papagayo would end up in an unusable state if RebuildVoiceList threw an exception (perhaps an academic concern) because in this case fRebuildingList is never reset.
(4) Using up and down keys to select different voices in the voice list did not change the current voice (another simple fix)
I could have changed very much less to fix (2) and (3) but it seemed as though the difficulty arose because of the idea of rebuilding the voice list whenever anything happens to it. It wasn't very hard to change it to a more standard Qt way of doing things.

This works on Ubuntu 20.04. I tried to test it on Windows 10 but I haven't convinced it to build yet. I will try again.